### PR TITLE
- Resolve: 'NoneType' object has no attribute 'startswith'

### DIFF
--- a/backend/garpix_menu/models/menu_item.py
+++ b/backend/garpix_menu/models/menu_item.py
@@ -36,7 +36,7 @@ class MenuItem(MPTTModel):
     def get_link(self):
         if self.page is not None:
             return self.page.get_absolute_url()
-        elif self.url is not None or self.url != '':
+        elif self.url is not None and self.url != '':
             if self.url.startswith('/'):
                 current_language_code_url_prefix = translation.get_language()
                 if current_language_code_url_prefix == settings.LANGUAGE_CODE:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56487358/126230310-e355704e-6525-4ed6-8860-ffaf3c968ae2.png)

